### PR TITLE
Added microns option for coordinates

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -10,6 +10,7 @@ from bg_atlasapi import core
 COMPRESSED_FILENAME = "atlas.tar.gz"
 
 __all__ = [
+    "ExampleAtlas",
     "FishAtlas",
     "RatAtlas",
     "AllenBrain25Um",

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -15,11 +15,13 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 def check_internet_connection(
     url="http://www.google.com/", timeout=5, raise_error=True
 ):
-    """
-        Check that there is an internet connection
-
-        :param url: url to use for testing (Default value = 'http://www.google.com/')
-        :param timeout:  timeout to wait for [in seconds] (Default value = 5)
+    """Check that there is an internet connection
+    url : str
+        url to use for testing (Default value = 'http://www.google.com/')
+    timeout : int
+        timeout to wait for [in seconds] (Default value = 5).
+    raise_error : bool
+        if false, warning but no error.
     """
 
     try:
@@ -36,6 +38,16 @@ def check_internet_connection(
 
 
 def retrieve_over_http(url, output_file_path):
+    """Download file from remote location, with progress bar.
+
+    Parameters
+    ----------
+    url : str
+        Remote URL.
+    output_file_path : str or Path
+        Full file destination for download.
+
+    """
     CHUNK_SIZE = 4096
     response = requests.get(url, stream=True)
 
@@ -58,18 +70,22 @@ def retrieve_over_http(url, output_file_path):
 
 
 def conf_from_url(url):
+    """Read conf file from an URL.
+    Parameters
+    ----------
+    url : str
+        conf file url (in a repo, make sure the "raw" url is passed)
+
+    Returns
+    -------
+    conf object
+
+    """
     text = requests.get(url).text
     config = configparser.ConfigParser()
     config.read_string(text)
 
     return config
-
-
-def get_latest_atlases_version():
-    # TODO download version from online
-
-    versions = read_json("docs/atlases/latest_version.json")
-    return versions
 
 
 # --------------------------------- File I/O --------------------------------- #

--- a/tests/test_core_atlas.py
+++ b/tests/test_core_atlas.py
@@ -55,10 +55,23 @@ def test_structures(atlas):
     "coords", [[39.0, 36.0, 57.0], (39, 36, 57), np.array([39.0, 36.0, 57.0])]
 )
 def test_data_from_coords(atlas, coords):
+    res = atlas.resolution
     assert atlas.structure_from_coords(coords) == 997
     assert atlas.structure_from_coords(coords, as_acronym=True) == "root"
+    assert (
+        atlas.structure_from_coords(
+            [c * r for c, r in zip(coords, res)], microns=True, as_acronym=True
+        )
+        == "root"
+    )
     assert atlas.hemisphere_from_coords(coords) == 0
     assert atlas.hemisphere_from_coords(coords, as_string=True) == "left"
+    assert (
+        atlas.hemisphere_from_coords(
+            [c * r for c, r in zip(coords, res)], microns=True, as_string=True
+        )
+        == "left"
+    )
 
 
 def test_meshfile_from_id(atlas):
@@ -80,8 +93,8 @@ def test_mesh_from_id(atlas):
     assert np.allclose(mesh.points[0], [7896.56, 3384.15, 503.781])
 
 
-def test_lookup(atlas):
-    df_lookup = atlas.lookup
+def test_lookup_df(atlas):
+    df_lookup = atlas.lookup_df
     df = pd.DataFrame(
         dict(
             acronym=["root", "grey", "CH"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pytest
+
+from bg_atlasapi import utils
+
+
+def test_http_check():
+    assert utils.check_internet_connection()
+    with pytest.raises(ConnectionError) as error:
+        utils.check_internet_connection(url="http://asd")
+    assert "No internet connection, try again" in str(error)
+
+    assert not utils.check_internet_connection(
+        url="http://asd", raise_error=False
+    )


### PR DESCRIPTION
Addressing #45.
- Added microns option for coordinates;
- refactored `atlas.lookup` @FedeClaudi  to `atlas.lookup_df` - we could even set it to `atlas.lookup_dataframe` for being more informative;
- listed ExampleAtlas together with the rest in __all__