### PR TITLE
Version 0.2.0 does not work with bg-space 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ meshio
 click
 rich
 tqdm>=4.46.1
-bg-space
+bg-space>=0.5.0


### PR DESCRIPTION
I don't know exactly what is the minimum version of bg-space so I set it to above 0.5.0. 
This is important for people who upgrade.