### PR TITLE
Remove auto-print upon BrainGlobeAtlas construction

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -84,8 +84,6 @@ class BrainGlobeAtlas(core.Atlas):
 
         if check_latest:
             self.check_latest_version()
-        if print_authors:
-            print(self)
 
     @property
     def local_version(self):

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -48,7 +48,6 @@ class BrainGlobeAtlas(core.Atlas):
         brainglobe_dir=None,
         interm_download_dir=None,
         check_latest=True,
-        print_authors=True,
     ):
         self.atlas_name = atlas_name
 


### PR DESCRIPTION
Hi,

This is a very minor change request, so no worries if it's ignored, but I noticed that BrainGlobeAtlas() prints itself when it is initialized.  This is different than the convention, and ends up adding unnecessary output to the standard output during normal operations.  For my use case (wrapping BrainGlobeAtlas in an application), it would mean suppressing the bg-atlasapi output in order to have control over my application's output. It also leads to a double-printing when someone explicitly requests output in a jupyter notebook cell, as in:

```python
atlas = BrainGlobeAtlas("allen_mouse_25um")
atlas
```

The pull request just removes the extra print statement in BrainGlobeAtlas.__init__(), leaving the user to decide if they want to see the output themselves.

Best wishes,

Nick