### PR TITLE
Atlas metadata print out

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -186,15 +186,12 @@ class BrainGlobeAtlas(core.Atlas):
             return False
         return True
 
-    # def __repr__(self):
-    #     """Fancy print for the atlas providing authors information."""
-    #     meta = self.metadata
-    #     name_split = self.atlas_name.split("_")
-    #     pretty_name = "{} {} atlas (res. {})".format(*name_split)
-    #     pretty_string = (
-    #         f"{pretty_name}\nFrom: {meta['atlas_link']} ({meta['citation']} )"
-    #     )
-    #     return pretty_string
+    def __repr__(self):
+        """Fancy print for the atlas providing authors information."""
+        meta = self.metadata
+        name_split = self.atlas_name.split("_")
+        pretty_name = "{} {} atlas (res. {})".format(*name_split)
+        return pretty_name
 
     
     def __str__(self):

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -1,14 +1,8 @@
 from pathlib import Path
 import tarfile
 import requests
-
 from rich import print as rprint
-from rich.table import Table
-from rich.panel import Panel
-from rich.pretty import Pretty
-from rich.text import Text
-from rich.console import Console
-from io import StringIO
+
 
 from bg_atlasapi import utils, config, core, descriptors
 
@@ -185,81 +179,3 @@ class BrainGlobeAtlas(core.Atlas):
             )
             return False
         return True
-
-    def __repr__(self):
-        """Fancy print for the atlas providing authors information."""
-        name_split = self.atlas_name.split("_")
-        pretty_name = "{} {} atlas (res. {})".format(*name_split)
-        return pretty_name
-
-    def __str__(self):
-        """
-        If the atlas metadat are to be printed
-        with the built in print function instead of rich's, then
-        print the rich panel as a string.
-
-        It will miss the colors.
-
-        """
-        buf = StringIO()
-        _console = Console(file=buf, force_jupyter=False)
-        _console.print(self)
-
-        return buf.getvalue()
-
-    def __rich_console__(self, *args):
-        """
-        Method for rich API's console protocol.
-        Prints the atlas metadata as a table nested in a panel
-        """
-        orange = "#f59e42"
-        dimorange = "#b56510"
-        gray = "#A9A9A9"
-        mocassin = "#FFE4B5"
-        cit_name, cit_link = self.metadata["citation"].split(", ")
-
-        # Create a rich table
-        tb = Table(
-            box=None,
-            show_lines=False,
-            title=self.atlas_name.replace("_", " ").capitalize(),
-            title_style=f"bold {orange}",
-        )
-
-        # Add entries to table
-        tb.add_column(
-            style=f"bold {mocassin}",
-            justify="right",
-            min_width=8,
-            max_width=40,
-        )
-        tb.add_column(min_width=20, max_width=48)
-
-        tb.add_row(
-            "name:",
-            Text.from_markup(
-                self.metadata["name"]
-                + f' [{gray}](v{self.metadata["version"]})'
-            ),
-        )
-        tb.add_row(
-            "species:", Text.from_markup(f'[i]{self.metadata["species"]}')
-        )
-        tb.add_row(
-            "citation:", Text.from_markup(f"{cit_name} [{gray}]{cit_link}")
-        )
-        tb.add_row("link:", Text.from_markup(self.metadata["atlas_link"]))
-
-        tb.add_row("")
-        tb.add_row(
-            "orientation:",
-            Text.from_markup(f"[bold]{self.metadata['orientation']}"),
-        )
-        tb.add_row("symmetric:", Pretty(self.metadata["symmetric"]))
-        tb.add_row("resolution:", Pretty(self.metadata["resolution"]))
-        tb.add_row("shape:", Pretty(self.metadata["shape"]))
-
-        # Fit into panel and yield
-        panel = Panel.fit(tb, border_style=dimorange)
-
-        yield panel

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -2,7 +2,13 @@ from pathlib import Path
 import tarfile
 import requests
 
-from rich import print as rprint
+# from rich import print
+from rich.table import Table
+from rich.panel import Panel
+from rich.pretty import Pretty
+from rich.text import Text
+from rich.console import Console
+from io import StringIO
 
 from bg_atlasapi import utils, config, core, descriptors
 
@@ -74,7 +80,7 @@ class BrainGlobeAtlas(core.Atlas):
             if self.remote_version is None:
                 raise ValueError(f"{atlas_name} is not a valid atlas name!")
 
-            rprint(
+            print(
                 f"[magenta2]Bgatlas_api: {self.atlas_name} not found locally. Downloading...[magenta2]"
             )
             self.download_extract_file()
@@ -175,7 +181,7 @@ class BrainGlobeAtlas(core.Atlas):
         online = _version_str_from_tuple(self.remote_version)
 
         if local != online:
-            rprint(
+            print(
                 f"[b][magenta2]Bg_atlasapi[/b]: [b]{self.atlas_name}[/b] version [b]{local}[/b] is not the latest available ([b]{online}[/b]). "
                 + "To update the atlas run in the terminal:[/magenta2]\n"
                 + f"    [gold1]brainglobe update -a {self.atlas_name}[/gold1]"
@@ -183,12 +189,65 @@ class BrainGlobeAtlas(core.Atlas):
             return False
         return True
 
-    def __repr__(self):
-        """Fancy print for the atlas providing authors information."""
-        meta = self.metadata
-        name_split = self.atlas_name.split("_")
-        pretty_name = "{} {} atlas (res. {})".format(*name_split)
-        pretty_string = (
-            f"{pretty_name}\nFrom: {meta['atlas_link']} ({meta['citation']} )"
-        )
-        return pretty_string
+    # def __repr__(self):
+    #     """Fancy print for the atlas providing authors information."""
+    #     meta = self.metadata
+    #     name_split = self.atlas_name.split("_")
+    #     pretty_name = "{} {} atlas (res. {})".format(*name_split)
+    #     pretty_string = (
+    #         f"{pretty_name}\nFrom: {meta['atlas_link']} ({meta['citation']} )"
+    #     )
+    #     return pretty_string
+
+    
+    def __str__(self):
+        """
+            If the atlas metadat are to be printed
+            with the built in print function instead of rich's, then
+            print the rich panel as a string.
+
+            It will miss the colors.
+        
+        """
+        buf = StringIO()
+        _console = Console(file=buf, force_jupyter=False)
+        _console.print(self)
+
+        return buf.getvalue()
+
+
+    def __rich_console__(self, *args):
+        """
+            Method for rich API's console protocol.
+            Prints the atlas metadata as a table nested in a panel
+        """
+        orange = "#f59e42"
+        dimorange = "#b56510"
+        gray = "#A9A9A9"
+        mocassin = "#FFE4B5"
+        cit_name, cit_link = self.metadata['citation'].split(', ')
+
+        # Create a rich table
+        tb = Table(box=None, show_lines=False, 
+                    title=self.atlas_name.replace('_', ' ').capitalize(), 
+                    title_style=f'bold {orange} u')
+
+        # Add entries to table
+        tb.add_column(style=f'bold {mocassin}', justify='right', min_width=8, max_width=40)
+        tb.add_column(min_width=20, max_width=48)
+
+        tb.add_row('name:', Text.from_markup(self.metadata['name'] + f' [{gray}](v{self.metadata["version"]})'))
+        tb.add_row('species:', Text.from_markup(f'[i]{self.metadata["species"]}'))
+        tb.add_row('citation:', Text.from_markup(f'{cit_name} [{gray}]{cit_link}'))
+        tb.add_row('link:', Text.from_markup(self.metadata['atlas_link']))
+
+        tb.add_row('')
+        tb.add_row('orientation:', Text.from_markup(f"[bold]{self.metadata['orientation']}"))
+        tb.add_row('symmetric:', Pretty(self.metadata['symmetric']))
+        tb.add_row('resolution:', Pretty(self.metadata['resolution']))
+        tb.add_row('shape:', Pretty(self.metadata['shape']))
+
+        # Fit into panel and yield
+        panel = Panel.fit(tb, border_style=dimorange)
+
+        yield panel

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -188,20 +188,18 @@ class BrainGlobeAtlas(core.Atlas):
 
     def __repr__(self):
         """Fancy print for the atlas providing authors information."""
-        meta = self.metadata
         name_split = self.atlas_name.split("_")
         pretty_name = "{} {} atlas (res. {})".format(*name_split)
         return pretty_name
 
-    
     def __str__(self):
         """
-            If the atlas metadat are to be printed
-            with the built in print function instead of rich's, then
-            print the rich panel as a string.
+        If the atlas metadat are to be printed
+        with the built in print function instead of rich's, then
+        print the rich panel as a string.
 
-            It will miss the colors.
-        
+        It will miss the colors.
+
         """
         buf = StringIO()
         _console = Console(file=buf, force_jupyter=False)
@@ -209,37 +207,57 @@ class BrainGlobeAtlas(core.Atlas):
 
         return buf.getvalue()
 
-
     def __rich_console__(self, *args):
         """
-            Method for rich API's console protocol.
-            Prints the atlas metadata as a table nested in a panel
+        Method for rich API's console protocol.
+        Prints the atlas metadata as a table nested in a panel
         """
         orange = "#f59e42"
         dimorange = "#b56510"
         gray = "#A9A9A9"
         mocassin = "#FFE4B5"
-        cit_name, cit_link = self.metadata['citation'].split(', ')
+        cit_name, cit_link = self.metadata["citation"].split(", ")
 
         # Create a rich table
-        tb = Table(box=None, show_lines=False, 
-                    title=self.atlas_name.replace('_', ' ').capitalize(), 
-                    title_style=f'bold {orange} u')
+        tb = Table(
+            box=None,
+            show_lines=False,
+            title=self.atlas_name.replace("_", " ").capitalize(),
+            title_style=f"bold {orange} u",
+        )
 
         # Add entries to table
-        tb.add_column(style=f'bold {mocassin}', justify='right', min_width=8, max_width=40)
+        tb.add_column(
+            style=f"bold {mocassin}",
+            justify="right",
+            min_width=8,
+            max_width=40,
+        )
         tb.add_column(min_width=20, max_width=48)
 
-        tb.add_row('name:', Text.from_markup(self.metadata['name'] + f' [{gray}](v{self.metadata["version"]})'))
-        tb.add_row('species:', Text.from_markup(f'[i]{self.metadata["species"]}'))
-        tb.add_row('citation:', Text.from_markup(f'{cit_name} [{gray}]{cit_link}'))
-        tb.add_row('link:', Text.from_markup(self.metadata['atlas_link']))
+        tb.add_row(
+            "name:",
+            Text.from_markup(
+                self.metadata["name"]
+                + f' [{gray}](v{self.metadata["version"]})'
+            ),
+        )
+        tb.add_row(
+            "species:", Text.from_markup(f'[i]{self.metadata["species"]}')
+        )
+        tb.add_row(
+            "citation:", Text.from_markup(f"{cit_name} [{gray}]{cit_link}")
+        )
+        tb.add_row("link:", Text.from_markup(self.metadata["atlas_link"]))
 
-        tb.add_row('')
-        tb.add_row('orientation:', Text.from_markup(f"[bold]{self.metadata['orientation']}"))
-        tb.add_row('symmetric:', Pretty(self.metadata['symmetric']))
-        tb.add_row('resolution:', Pretty(self.metadata['resolution']))
-        tb.add_row('shape:', Pretty(self.metadata['shape']))
+        tb.add_row("")
+        tb.add_row(
+            "orientation:",
+            Text.from_markup(f"[bold]{self.metadata['orientation']}"),
+        )
+        tb.add_row("symmetric:", Pretty(self.metadata["symmetric"]))
+        tb.add_row("resolution:", Pretty(self.metadata["resolution"]))
+        tb.add_row("shape:", Pretty(self.metadata["shape"]))
 
         # Fit into panel and yield
         panel = Panel.fit(tb, border_style=dimorange)

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import tarfile
 import requests
 
-# from rich import print
+from rich import print as rprint
 from rich.table import Table
 from rich.panel import Panel
 from rich.pretty import Pretty
@@ -79,7 +79,7 @@ class BrainGlobeAtlas(core.Atlas):
             if self.remote_version is None:
                 raise ValueError(f"{atlas_name} is not a valid atlas name!")
 
-            print(
+            rprint(
                 f"[magenta2]Bgatlas_api: {self.atlas_name} not found locally. Downloading...[magenta2]"
             )
             self.download_extract_file()
@@ -178,7 +178,7 @@ class BrainGlobeAtlas(core.Atlas):
         online = _version_str_from_tuple(self.remote_version)
 
         if local != online:
-            print(
+            rprint(
                 f"[b][magenta2]Bg_atlasapi[/b]: [b]{self.atlas_name}[/b] version [b]{local}[/b] is not the latest available ([b]{online}[/b]). "
                 + "To update the atlas run in the terminal:[/magenta2]\n"
                 + f"    [gold1]brainglobe update -a {self.atlas_name}[/gold1]"
@@ -223,7 +223,7 @@ class BrainGlobeAtlas(core.Atlas):
             box=None,
             show_lines=False,
             title=self.atlas_name.replace("_", " ").capitalize(),
-            title_style=f"bold {orange} u",
+            title_style=f"bold {orange}",
         )
 
         # Add entries to table

--- a/bg_atlasapi/core.py
+++ b/bg_atlasapi/core.py
@@ -3,10 +3,12 @@ import pandas as pd
 import numpy as np
 from collections import UserDict
 import warnings
+from rich.console import Console
+from io import StringIO
 
 from bg_space import AnatomicalSpace
 
-from bg_atlasapi.utils import read_json, read_tiff
+from bg_atlasapi.utils import read_json, read_tiff, _rich_atlas_metadata
 from bg_atlasapi.structure_class import StructuresDict
 from bg_atlasapi.descriptors import (
     METADATA_FILENAME,
@@ -69,6 +71,35 @@ class Atlas:
         self._annotation = None
         self._hemispheres = None
         self._lookup = None
+
+    def __repr__(self):
+        """Fancy print for the atlas providing authors information."""
+        name_split = self.atlas_name.split("_")
+        pretty_name = "{} {} atlas (res. {})".format(*name_split)
+        return pretty_name
+
+    def __str__(self):
+        """
+        If the atlas metadat are to be printed
+        with the built in print function instead of rich's, then
+        print the rich panel as a string.
+
+        It will miss the colors.
+
+        """
+        buf = StringIO()
+        _console = Console(file=buf, force_jupyter=False)
+        _console.print(self)
+
+        return buf.getvalue()
+
+    def __rich_console__(self, *args):
+        """
+        Method for rich API's console protocol.
+        Prints the atlas metadata as a table nested in a panel
+        """
+        panel = _rich_atlas_metadata(self.atlas_name, self.metadata)
+        yield panel
 
     @property
     def resolution(self):

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -11,8 +11,60 @@ from rich.progress import (
     TimeRemainingColumn,
     Progress,
 )
+from rich.table import Table
+from rich.panel import Panel
+from rich.pretty import Pretty
+from rich.text import Text
 
 logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+def _rich_atlas_metadata(atlas_name, metadata):
+    orange = "#f59e42"
+    dimorange = "#b56510"
+    gray = "#A9A9A9"
+    mocassin = "#FFE4B5"
+    cit_name, cit_link = metadata["citation"].split(", ")
+
+    # Create a rich table
+    tb = Table(
+        box=None,
+        show_lines=False,
+        title=atlas_name.replace("_", " ").capitalize(),
+        title_style=f"bold {orange}",
+    )
+
+    # Add entries to table
+    tb.add_column(
+        style=f"bold {mocassin}",
+        justify="right",
+        min_width=8,
+        max_width=40,
+    )
+    tb.add_column(min_width=20, max_width=48)
+
+    tb.add_row(
+        "name:",
+        Text.from_markup(
+            metadata["name"] + f' [{gray}](v{metadata["version"]})'
+        ),
+    )
+    tb.add_row("species:", Text.from_markup(f'[i]{metadata["species"]}'))
+    tb.add_row("citation:", Text.from_markup(f"{cit_name} [{gray}]{cit_link}"))
+    tb.add_row("link:", Text.from_markup(metadata["atlas_link"]))
+
+    tb.add_row("")
+    tb.add_row(
+        "orientation:",
+        Text.from_markup(f"[bold]{metadata['orientation']}"),
+    )
+    tb.add_row("symmetric:", Pretty(metadata["symmetric"]))
+    tb.add_row("resolution:", Pretty(metadata["resolution"]))
+    tb.add_row("shape:", Pretty(metadata["shape"]))
+
+    # Fit into panel and yield
+    panel = Panel.fit(tb, border_style=dimorange)
+    return panel
 
 
 def atlas_repr_from_name(name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pandas
 requests
 meshio
 click
-rich>=8.0.0
+rich>=9.0.0
 bg-space>=0.5.0


### PR DESCRIPTION
Okay so I've added a `__rich_console__` method to the `BGAtlas` class, that's what's used by rich's `Console` for printing objects. If users use the builtin `print` function than `__str__` will be used instead, which prints the same but without colors. 

This is what it looks like:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/17436313/96756372-ebc86600-13cb-11eb-8722-b6ceb884ece2.png">

and with the normal print
<img width="417" alt="image" src="https://user-images.githubusercontent.com/17436313/96756401-f5ea6480-13cb-11eb-8aa5-37bad9ccb1c7.png">

and `__repr__` returns: 
<img width="213" alt="image" src="https://user-images.githubusercontent.com/17436313/96756426-00a4f980-13cc-11eb-9c4c-525b1849dda9.png">
