### PR TITLE
List all available atlases and their versions in machine-readable format (2)

### DIFF
--- a/bg_atlasapi/list_atlases.py
+++ b/bg_atlasapi/list_atlases.py
@@ -52,6 +52,15 @@ def get_local_atlas_version(atlas_name):
     ][0]
 
 
+def get_all_atlases_lastversions():
+    """Read from URL all available last versions"""
+    available_atlases = utils.conf_from_url(
+        descriptors.remote_url_base.format("last_versions.conf")
+    )
+    available_atlases = dict(available_atlases["atlases"])
+    return available_atlases
+
+
 def get_atlases_lastversions():
     """
     Returns
@@ -60,11 +69,7 @@ def get_atlases_lastversions():
         A dictionary with metadata about already installed atlases.
     """
 
-    # Read from URL all available last versions:
-    available_atlases = utils.conf_from_url(
-        descriptors.remote_url_base.format("last_versions.conf")
-    )
-    available_atlases = dict(available_atlases["atlases"])
+    available_atlases = get_all_atlases_lastversions()
 
     # Get downloaded atlases looping over folders in brainglobe directory:
     atlases = {}
@@ -95,11 +100,7 @@ def show_atlases(show_local_path=False):
 
     """
 
-    # Get available_atlases:
-    available_atlases = utils.conf_from_url(
-        BrainGlobeAtlas._remote_url_base.format("last_versions.conf")
-    )
-    available_atlases = dict(available_atlases["atlases"])
+    available_atlases = get_all_atlases_lastversions()
 
     # Get local atlases:
     atlases = get_atlases_lastversions()


### PR DESCRIPTION
Hi,

I was looking for a way to put a list of all the brainglobe atlases (as strings, to pass to the BrainGlobeAtlas constructor), and added the function by refactoring out a step in the get_local_atlas_version() function.  It works like so:

```python
>> from bg_atlasapi.list_atlases import get_all_atlases_lastversions
>> get_all_atlases_lastversions()
{ "mouse_allen_25um": "1.0",
 "rat_allen_100um": "1.2",
  ...
}
```

I've put this into slicereg, but it'd be great to put something like this upstream.  If there is a better way to get this information, though, or one I missed, I'd be happy to use it!

Best wishes,

Nick