### PR TITLE
Fix NumPy future warning on get structure mask

### DIFF
--- a/bg_atlasapi/core.py
+++ b/bg_atlasapi/core.py
@@ -346,7 +346,7 @@ class Atlas:
         for descendant in descendants:
             descendant_id = self.structures[descendant]["id"]
             mask_stack[self.annotation == descendant_id] = structure_id
-        mask_stack[[self.annotation == structure_id]] = structure_id
+        mask_stack[self.annotation == structure_id] = structure_id
 
         return mask_stack
 


### PR DESCRIPTION
Thanks so much for the package, it is great!
One small thing I noticed on the latest version:


In core.py line 349, the boolean-valued array was wrapped inside another array.
I may have missed a reason for this, but the extra array brackets [] shouldn't be needed.
This line throws a future warning on the latest version of NumPy.
The new code also matches the code on line 348 for checking descendants.