### PR TITLE
moved print to BrainGlobeAtlas

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -2,6 +2,10 @@ from pathlib import Path
 import tarfile
 import requests
 from rich import print as rprint
+from rich.console import Console
+from io import StringIO
+from bg_atlasapi.utils import _rich_atlas_metadata
+
 
 
 from bg_atlasapi import utils, config, core, descriptors
@@ -179,3 +183,32 @@ class BrainGlobeAtlas(core.Atlas):
             )
             return False
         return True
+
+    def __repr__(self):
+        """Fancy print providing atlas information."""
+        name_split = self.atlas_name.split("_")
+        pretty_name = "{} {} atlas (res. {})".format(*name_split)
+        return pretty_name
+
+    def __str__(self):
+        """
+        If the atlas metadat are to be printed
+        with the built in print function instead of rich's, then
+        print the rich panel as a string.
+
+        It will miss the colors.
+
+        """
+        buf = StringIO()
+        _console = Console(file=buf, force_jupyter=False)
+        _console.print(self)
+
+        return buf.getvalue()
+
+    def __rich_console__(self, *args):
+        """
+        Method for rich API's console protocol.
+        Prints the atlas metadata as a table nested in a panel
+        """
+        panel = _rich_atlas_metadata(self.atlas_name, self.metadata)
+        yield panel

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -7,7 +7,6 @@ from io import StringIO
 from bg_atlasapi.utils import _rich_atlas_metadata
 
 
-
 from bg_atlasapi import utils, config, core, descriptors
 
 

--- a/bg_atlasapi/core.py
+++ b/bg_atlasapi/core.py
@@ -3,12 +3,10 @@ import pandas as pd
 import numpy as np
 from collections import UserDict
 import warnings
-from rich.console import Console
-from io import StringIO
 
 from bg_space import AnatomicalSpace
 
-from bg_atlasapi.utils import read_json, read_tiff, _rich_atlas_metadata
+from bg_atlasapi.utils import read_json, read_tiff
 from bg_atlasapi.structure_class import StructuresDict
 from bg_atlasapi.descriptors import (
     METADATA_FILENAME,
@@ -71,35 +69,6 @@ class Atlas:
         self._annotation = None
         self._hemispheres = None
         self._lookup = None
-
-    def __repr__(self):
-        """Fancy print for the atlas providing authors information."""
-        name_split = self.atlas_name.split("_")
-        pretty_name = "{} {} atlas (res. {})".format(*name_split)
-        return pretty_name
-
-    def __str__(self):
-        """
-        If the atlas metadat are to be printed
-        with the built in print function instead of rich's, then
-        print the rich panel as a string.
-
-        It will miss the colors.
-
-        """
-        buf = StringIO()
-        _console = Console(file=buf, force_jupyter=False)
-        _console.print(self)
-
-        return buf.getvalue()
-
-    def __rich_console__(self, *args):
-        """
-        Method for rich API's console protocol.
-        Prints the atlas metadata as a table nested in a panel
-        """
-        panel = _rich_atlas_metadata(self.atlas_name, self.metadata)
-        yield panel
 
     @property
     def resolution(self):


### PR DESCRIPTION
Printing require an atlas name, which is enforced only in the BrainGlobeAtlas and does not necessarily fit requirements for a folder of a locally packaged atlas. I just moved the printing-related code to the child class. Nothing major.