### PR TITLE
Changes to config file location

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -51,11 +51,12 @@ class BrainGlobeAtlas(core.Atlas):
         brainglobe_dir=None,
         interm_download_dir=None,
         check_latest=True,
+        config_dir=None,
     ):
         self.atlas_name = atlas_name
 
         # Read BrainGlobe configuration file:
-        conf = config.read_config()
+        conf = config.read_config(config_dir)
 
         # Use either input locations or locations from the config file,
         # and create directory if it does not exist:

--- a/bg_atlasapi/config.py
+++ b/bg_atlasapi/config.py
@@ -27,7 +27,7 @@ TEMPLATE_CONF_DICT = {
 }
 
 
-def write_default_config(path=CONFIG_PATH, template=TEMPLATE_CONF_DICT):
+def write_default_config(path=None, template=None):
     """Write configuration file at first repo usage. In this way,
     we don't need to keep a confusing template config file in the repo.
 
@@ -39,6 +39,10 @@ def write_default_config(path=CONFIG_PATH, template=TEMPLATE_CONF_DICT):
         Template of the config file to be written (optional).
 
     """
+    if path is None:
+        path = CONFIG_PATH
+    if template is None:
+        template = TEMPLATE_CONF_DICT
 
     conf = configparser.ConfigParser()
     for k, val in template.items():
@@ -49,7 +53,7 @@ def write_default_config(path=CONFIG_PATH, template=TEMPLATE_CONF_DICT):
         conf.write(f)
 
 
-def read_config(path=CONFIG_PATH):
+def read_config(path=None):
     """Read BrainGlobe config.
 
     Parameters
@@ -62,6 +66,8 @@ def read_config(path=CONFIG_PATH):
     ConfigParser object
         brainglobe configuration
     """
+    if path is None:
+        path = CONFIG_PATH
 
     # If no config file exists yet, write the default one:
     if not path.exists():
@@ -73,7 +79,7 @@ def read_config(path=CONFIG_PATH):
     return conf
 
 
-def write_config_value(key, val, path=CONFIG_PATH):
+def write_config_value(key, val, path=None):
     """Write a new value in the config file. To make things simple, ignore
     sections and look directly for matching parameters names.
 
@@ -87,13 +93,16 @@ def write_config_value(key, val, path=CONFIG_PATH):
         Path of the config file (optional).
 
     """
+    if path is None:
+        path = CONFIG_PATH
+    
     conf = configparser.ConfigParser()
     conf.read(path)
     for sect_name, sect_dict in conf.items():
         if key in sect_dict.keys():
             conf[sect_name][key] = str(val)
 
-    with open(CONFIG_PATH, "w") as f:
+    with open(path, "w") as f:
         conf.write(f)
 
 

--- a/bg_atlasapi/config.py
+++ b/bg_atlasapi/config.py
@@ -1,10 +1,21 @@
+"""Utilities for reading and modifying brainglob configuration.
+
+Configuration is stored in a file.  By default, the file is in
+stored in the directory "$HOME/.config/brainglobe".   
+This can be overridden with the environmental variable 
+BRAINGLOBE_CONFIG_DIR.
+"""
+
+import os
 import configparser
 from pathlib import Path
 from pkg_resources import resource_filename
 import click
 
 CONFIG_FILENAME = "bg_config.conf"
-CONFIG_PATH = Path(resource_filename("bg_atlasapi", CONFIG_FILENAME))
+CONFIG_DEFAULT_DIR = Path.home() / ".config" / "brainglobe"
+CONFIG_DIR = Path(os.environ.get("BRAINGLOBE_CONFIG_DIR", CONFIG_DEFAULT_DIR))
+CONFIG_PATH = CONFIG_DIR / CONFIG_FILENAME
 
 # 2 level dictionary for sections and values:
 DEFAULT_PATH = Path.home() / ".brainglobe"
@@ -33,6 +44,7 @@ def write_default_config(path=CONFIG_PATH, template=TEMPLATE_CONF_DICT):
     for k, val in template.items():
         conf[k] = val
 
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         conf.write(f)
 

--- a/bg_atlasapi/config.py
+++ b/bg_atlasapi/config.py
@@ -1,15 +1,14 @@
 """Utilities for reading and modifying brainglob configuration.
 
 Configuration is stored in a file.  By default, the file is in
-stored in the directory "$HOME/.config/brainglobe".   
-This can be overridden with the environmental variable 
+stored in the directory "$HOME/.config/brainglobe".
+This can be overridden with the environmental variable
 BRAINGLOBE_CONFIG_DIR.
 """
 
 import os
 import configparser
 from pathlib import Path
-from pkg_resources import resource_filename
 import click
 
 CONFIG_FILENAME = "bg_config.conf"

--- a/bg_atlasapi/config.py
+++ b/bg_atlasapi/config.py
@@ -95,7 +95,7 @@ def write_config_value(key, val, path=None):
     """
     if path is None:
         path = CONFIG_PATH
-    
+
     conf = configparser.ConfigParser()
     conf.read(path)
     for sect_name, sect_dict in conf.items():


### PR DESCRIPTION
Change config file directory.  Default directory changed from within site-packages to <HOME>/.config/brainglobe .   User can override with env var BRAINGLOBE_CONFIG_DIR.

Add config dir parameter to BrainGlobeAtlas

Fixed bug in config.write_config_value where config file was written to default location even if custom path passed in.

This change allows the caller to override the config directory in code, which takes precedence over the default location and the BRAINGLOBE_CONFIG_DIR variables.  Clients can use this to set the config dir via their command-line flags.