### PR TITLE
Lint setup fix paddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
             types: [text]
             types_or: [python, cython]
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
+      rev: v4.3.0
       hooks:
           - id: check-docstring-first
           - id: check-executables-have-shebangs
@@ -28,3 +28,9 @@ repos:
       rev: 22.3.0
       hooks:
           - id: black
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v0.961
+      hooks:
+          - id: mypy
+            additional_dependencies:
+                - types-requests


### PR DESCRIPTION
Addressing question in #122 

> Ok, happy to learn here! Can I ask your help to fix the mypy error that I am getting there? On a python 3.9 (where I am testing this and where tests are running) I get complaints about missing setups in request. The recommendation seems to be to pip install types-requests but it does not fix it in my case, do you know what is happening?

So when using `pre-commit` it's essentially using its own `python` environment. So when you did `pip install types-requests` you did it in your environment, which is not the same as the one `pre-commit` uses. If you look in `$HOME/.cache/pre-commit` you can see where `pre-commit` is installing stuff. If I'm honest, I don't really know when `types-requests` is required here, but I had encountered something similar before with `types-setuptools` like [here](https://github.com/brainglobe/cellfinder-napari/blob/main/.pre-commit-config.yaml).
