### PR TITLE
Fix the `-` in requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,6 @@ coverage
 flake8
 gitpython
 isort
-pre - commit
+pre-commit
 pytest
-pytest - cov
+pytest-cov


### PR DESCRIPTION
This currently breaks `pip install -e .[dev]`