### PR TITLE
Allow `-h` and `--help` for help

### DIFF
--- a/bg_atlasapi/cli.py
+++ b/bg_atlasapi/cli.py
@@ -5,7 +5,7 @@ from bg_atlasapi.list_atlases import show_atlases
 from bg_atlasapi.update_atlases import install_atlas, update_atlas
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("command")
 @click.option("-s", "--show", is_flag=True)
 @click.option("-a", "--atlas_name")


### PR DESCRIPTION
Fixes https://github.com/brainglobe/bg-atlasapi/issues/81

Gives option for `-h` as well as `--help`. Sounds like the `click` maintainers have no intention of making this the default behaviour https://github.com/pallets/click/issues/2132