### PR TITLE
Add an optional attribute to handle updates during atlas downloads

### DIFF
--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -38,6 +38,9 @@ class BrainGlobeAtlas(core.Atlas):
         instantiation and to suppress warnings.
     print_authors : bool (optional)
         If true, disable default listing of the atlas reference.
+    fn_update : Callable
+        Handler function to update during download. Takes completed and total
+        bytes.
 
     """
 
@@ -51,8 +54,10 @@ class BrainGlobeAtlas(core.Atlas):
         interm_download_dir=None,
         check_latest=True,
         config_dir=None,
+        fn_update=None,
     ):
         self.atlas_name = atlas_name
+        self.fn_update = fn_update
 
         # Read BrainGlobe configuration file:
         conf = config.read_config(config_dir)
@@ -156,7 +161,7 @@ class BrainGlobeAtlas(core.Atlas):
         destination_path = self.interm_download_dir / COMPRESSED_FILENAME
 
         # Try to download atlas data
-        utils.retrieve_over_http(self.remote_url, destination_path)
+        utils.retrieve_over_http(self.remote_url, destination_path, self.fn_update)
 
         # Uncompress in brainglobe path:
         tar = tarfile.open(destination_path)

--- a/bg_atlasapi/bg_atlas.py
+++ b/bg_atlasapi/bg_atlas.py
@@ -161,7 +161,9 @@ class BrainGlobeAtlas(core.Atlas):
         destination_path = self.interm_download_dir / COMPRESSED_FILENAME
 
         # Try to download atlas data
-        utils.retrieve_over_http(self.remote_url, destination_path, self.fn_update)
+        utils.retrieve_over_http(
+            self.remote_url, destination_path, self.fn_update
+        )
 
         # Uncompress in brainglobe path:
         tar = tarfile.open(destination_path)

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -1,6 +1,7 @@
 import configparser
 import json
 import logging
+from typing import Callable
 
 import requests
 import tifffile
@@ -128,7 +129,8 @@ def check_internet_connection(
     return False
 
 
-def retrieve_over_http(url, output_file_path):
+def retrieve_over_http(url, output_file_path,
+                       fn_update: Callable[[int, int], None] = None):
     """Download file from remote location, with progress bar.
 
     Parameters
@@ -137,6 +139,9 @@ def retrieve_over_http(url, output_file_path):
         Remote URL.
     output_file_path : str or Path
         Full file destination for download.
+    fn_update : Callable
+        Handler function to update during download. Takes completed and total
+        bytes.
 
     """
     # Make Rich progress bar
@@ -157,17 +162,25 @@ def retrieve_over_http(url, output_file_path):
 
     try:
         with progress:
+            tot = int(response.headers.get("content-length", 0))
             task_id = progress.add_task(
                 "download",
                 filename=output_file_path.name,
                 start=True,
-                total=int(response.headers.get("content-length", 0)),
+                total=tot,
             )
 
             with open(output_file_path, "wb") as fout:
+                advanced = 0
                 for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
                     fout.write(chunk)
-                    progress.update(task_id, advance=len(chunk), refresh=True)
+                    adv = len(chunk)
+                    progress.update(task_id, advance=adv, refresh=True)
+                    
+                    if fn_update:
+                        # update handler with completed and total bytes
+                        advanced += adv
+                        fn_update(advanced, tot)
 
     except requests.exceptions.ConnectionError:
         output_file_path.unlink()

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -129,8 +129,9 @@ def check_internet_connection(
     return False
 
 
-def retrieve_over_http(url, output_file_path,
-                       fn_update: Callable[[int, int], None] = None):
+def retrieve_over_http(
+    url, output_file_path, fn_update: Callable[[int, int], None] = None
+):
     """Download file from remote location, with progress bar.
 
     Parameters
@@ -176,7 +177,7 @@ def retrieve_over_http(url, output_file_path,
                     fout.write(chunk)
                     adv = len(chunk)
                     progress.update(task_id, advance=adv, refresh=True)
-                    
+
                     if fn_update:
                         # update handler with completed and total bytes
                         advanced += adv


### PR DESCRIPTION
## Description

**What is this PR**

Atlas download progress is currently handled within a Rich progress indicator, but external libraries do not have access to these updates. This PR adds an optional attribute to `BrainGlobeAtlas` to reference a handler that is updated during atlas downloads. This handler can be given as a function that takes the currently competed and total required bytes to download the given atlas.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Provides access to track real-time atlas download updates by external apps. There may be better ways to provide this functionality...I'm all ears to alternatives.

**What does this PR do?**

Adds a hook called by `bg-atlasapi` during atlas downloads.

## References

I am using this handler to update a progress bar in MagellanMapper when downloading atlases through BrainGlobe (see https://github.com/sanderslab/magellanmapper/pull/75).

## How has this PR been tested?

- Tested downloading the "kim_mouse_50um" atlas in bg-atlasapi in an interactive Python 3.6 session, where the handler is ignored and download proceeds as normal
- Tested in [MagellanMapper PR 75](https://github.com/sanderslab/magellanmapper/pull/75), which passes a function that updates the progress bar during atlas downloads

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Updated the docstrings with the changes. Also added a type hint to the handler to specify its expected parameters.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)