### PR TITLE
Error on warnings raised in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ exclude = ["tests*"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=bg_atlasapi"
+filterwarnings = [
+    "error",
+]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.black]
 target-version = ['py38', 'py39', 'py310', 'py311']

--- a/tests/test_core_atlas.py
+++ b/tests/test_core_atlas.py
@@ -42,14 +42,15 @@ def test_additional_ref_dict(temp_path):
     for k in ["1", "2"]:
         stack = np.ones((10, 20, 30)) * int(k)
         fake_data[k] = stack
-        tifffile.imsave(temp_path / f"{k}.tiff", stack)
+        tifffile.imwrite(temp_path / f"{k}.tiff", stack)
 
     add_ref_dict = AdditionalRefDict(fake_data.keys(), temp_path)
 
     for k, stack in add_ref_dict.items():
         assert add_ref_dict[k] == stack
 
-    assert add_ref_dict["3"] is None
+    with pytest.warns(UserWarning, match="No reference named 3"):
+        assert add_ref_dict["3"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_structure_dict.py
+++ b/tests/test_structure_dict.py
@@ -33,6 +33,7 @@ structures_list = [
 ]
 
 
+@pytest.mark.filterwarnings("ignore:No mesh filename for region root")
 def test_structure_indexing():
     structures_dict = StructuresDict(structures_list)
     print(structures_dict)


### PR DESCRIPTION
This PR catches any warnings that are emitted by tests, and errors on them. This is generally good practice, to make sure the code isn't emitting any warnings, or if it is that they are intended.

There were also some warnings I had to fix. Hopefully the fixes look right!