### PR TITLE
Fix download progress bar

### DIFF
--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -204,7 +204,7 @@ def retrieve_over_http(
 
 
 def get_download_size(url: str) -> int:
-    """Get file size based on the MB value found on the "src" page of each atlas
+    """Get file size based on the MB value on the "src" page of each atlas
 
     Parameters
     ----------
@@ -218,7 +218,7 @@ def get_download_size(url: str) -> int:
 
     Raises
     ------
-        requests.exceptions.HTTPError: If there's an issue with the HTTP request.
+        requests.exceptions.HTTPError: If there's an issue with HTTP request.
         ValueError: If the file size cannot be extracted from the response.
 
     """
@@ -232,14 +232,16 @@ def get_download_size(url: str) -> int:
         response.raise_for_status()
 
         response_string = response.content.decode("utf-8")
-        size_string = re.search(
+        search_result = re.search(
             "([0-9]+.[0-9] [MGK]B)|([0-9]+ [MGK]B)", response_string
         )
 
-        if not size_string:
-            raise ValueError("File size information not found in the response")
+        assert search_result is not None
 
-        size_string = size_string.group()
+        size_string = search_result.group()
+
+        assert size_string is not None
+
         size = float(size_string[:-3])
         prefix = size_string[-2]
 

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -105,7 +105,7 @@ def atlas_name_from_repr(name, resolution, major_vers=None, minor_vers=None):
 
 
 def check_internet_connection(
-        url="http://www.google.com/", timeout=5, raise_error=True
+    url="http://www.google.com/", timeout=5, raise_error=True
 ):
     """Check that there is an internet connection
     url : str
@@ -131,9 +131,9 @@ def check_internet_connection(
 
 
 def retrieve_over_http(
-        url,
-        output_file_path,
-        fn_update: Optional[Callable[[int, int], None]] = None,
+    url,
+    output_file_path,
+    fn_update: Optional[Callable[[int, int], None]] = None,
 ):
     """Download file from remote location, with progress bar.
 
@@ -179,16 +179,16 @@ def retrieve_over_http(
             )
 
             with open(output_file_path, "wb") as fout:
-                advanced = 0
+                completed = 0
                 for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
                     fout.write(chunk)
                     adv = len(chunk)
-                    progress.update(task_id, advance=adv, refresh=True)
+                    completed += adv
+                    progress.update(task_id, completed=min(completed, tot), refresh=True)
 
                     if fn_update:
                         # update handler with completed and total bytes
-                        advanced += adv
-                        fn_update(advanced, tot)
+                        fn_update(completed, tot)
 
     except requests.exceptions.ConnectionError:
         output_file_path.unlink()

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -172,7 +172,7 @@ def retrieve_over_http(
             if tot == 0:
                 try:
                     tot = get_download_size(url)
-                except Exception as e:
+                except Exception:
                     tot = 0
 
             task_id = progress.add_task(
@@ -188,7 +188,9 @@ def retrieve_over_http(
                     fout.write(chunk)
                     adv = len(chunk)
                     completed += adv
-                    progress.update(task_id, completed=min(completed, tot), refresh=True)
+                    progress.update(
+                        task_id, completed=min(completed, tot), refresh=True
+                    )
 
                     if fn_update:
                         # update handler with completed and total bytes
@@ -222,15 +224,17 @@ def get_download_size(url: str) -> int:
     """
     try:
         # Replace the 'raw' in the url with 'src'
-        url_split = url.split('/')
-        url_split[5] = 'src'
-        url = '/'.join(url_split)
+        url_split = url.split("/")
+        url_split[5] = "src"
+        url = "/".join(url_split)
 
         response = requests.get(url)
         response.raise_for_status()
 
         response_string = response.content.decode("utf-8")
-        size_string = re.search('([0-9]+.[0-9] [MGK]B)|([0-9]+ [MGK]B)', response_string)
+        size_string = re.search(
+            "([0-9]+.[0-9] [MGK]B)|([0-9]+ [MGK]B)", response_string
+        )
 
         if not size_string:
             raise ValueError("File size information not found in the response")
@@ -239,11 +243,11 @@ def get_download_size(url: str) -> int:
         size = float(size_string[:-3])
         prefix = size_string[-2]
 
-        if prefix == 'G':
+        if prefix == "G":
             size *= 1e9
-        elif prefix == 'M':
+        elif prefix == "M":
             size *= 1e6
-        elif prefix == 'K':
+        elif prefix == "K":
             size *= 1e3
         else:
             raise ValueError("File size information not found in the response")
@@ -252,9 +256,9 @@ def get_download_size(url: str) -> int:
 
     except requests.exceptions.HTTPError as e:
         raise e
-    except ValueError as e:
+    except ValueError:
         raise ValueError("File size information not found in the response.")
-    except IndexError as e:
+    except IndexError:
         raise IndexError("Improperly formatted URL")
 
 

--- a/bg_atlasapi/utils.py
+++ b/bg_atlasapi/utils.py
@@ -220,6 +220,7 @@ def get_download_size(url: str) -> int:
     ------
         requests.exceptions.HTTPError: If there's an issue with HTTP request.
         ValueError: If the file size cannot be extracted from the response.
+        IndexError: If the url is not formatted as expected
 
     """
     try:
@@ -233,7 +234,7 @@ def get_download_size(url: str) -> int:
 
         response_string = response.content.decode("utf-8")
         search_result = re.search(
-            "([0-9]+.[0-9] [MGK]B)|([0-9]+ [MGK]B)", response_string
+            r"([0-9]+\.[0-9] [MGK]B)|([0-9]+ [MGK]B)", response_string
         )
 
         assert search_result is not None
@@ -251,14 +252,12 @@ def get_download_size(url: str) -> int:
             size *= 1e6
         elif prefix == "K":
             size *= 1e3
-        else:
-            raise ValueError("File size information not found in the response")
 
         return int(size)
 
     except requests.exceptions.HTTPError as e:
         raise e
-    except ValueError:
+    except AssertionError:
         raise ValueError("File size information not found in the response.")
     except IndexError:
         raise IndexError("Improperly formatted URL")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_get_download_size_bad_url():
 
 
 def test_get_download_size_no_size_url():
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         utils.get_download_size(
             "https://gin.g-node.org/BrainGlobe/atlases/src/master/last_versions.conf"
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pytest
-import requests.exceptions
 
 from bg_atlasapi import utils
 
@@ -18,23 +17,36 @@ def test_http_check():
 
 
 def test_get_download_size_bad_url():
-    with pytest.raises(IndexError) as e:
+    with pytest.raises(IndexError):
         utils.get_download_size(url="http://asd")
 
 
 def test_get_download_size_no_size_url():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         utils.get_download_size(
             "https://gin.g-node.org/BrainGlobe/atlases/src/master/last_versions.conf"
         )
 
 
-@pytest.mark.parametrize("url, real_size",
+@pytest.mark.parametrize(
+    "url, real_size",
     [
-        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/example_mouse_100um_v1.2.tar.gz", 7.3),
-        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/allen_mouse_100um_v1.2.tar.gz", 61),
-        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/admba_3d_p56_mouse_25um_v1.0.tar.gz", 335),
-        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/osten_mouse_10um_v1.1.tar.gz", 3600)
+        (
+            "https://gin.g-node.org/BrainGlobe/atlases/raw/master/example_mouse_100um_v1.2.tar.gz",
+            7.3,
+        ),
+        (
+            "https://gin.g-node.org/BrainGlobe/atlases/raw/master/allen_mouse_100um_v1.2.tar.gz",
+            61,
+        ),
+        (
+            "https://gin.g-node.org/BrainGlobe/atlases/raw/master/admba_3d_p56_mouse_25um_v1.0.tar.gz",
+            335,
+        ),
+        (
+            "https://gin.g-node.org/BrainGlobe/atlases/raw/master/osten_mouse_10um_v1.1.tar.gz",
+            3600,
+        ),
     ],
 )
 def test_get_download_size(url, real_size):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import requests.exceptions
 
 from bg_atlasapi import utils
 
@@ -14,3 +15,31 @@ def test_http_check():
     assert not utils.check_internet_connection(
         url="http://asd", raise_error=False
     )
+
+
+def test_get_download_size_bad_url():
+    with pytest.raises(IndexError) as e:
+        utils.get_download_size(url="http://asd")
+
+
+def test_get_download_size_no_size_url():
+    with pytest.raises(ValueError) as e:
+        utils.get_download_size(
+            "https://gin.g-node.org/BrainGlobe/atlases/src/master/last_versions.conf"
+        )
+
+
+@pytest.mark.parametrize("url, real_size",
+    [
+        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/example_mouse_100um_v1.2.tar.gz", 7.3),
+        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/allen_mouse_100um_v1.2.tar.gz", 61),
+        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/admba_3d_p56_mouse_25um_v1.0.tar.gz", 335),
+        ("https://gin.g-node.org/BrainGlobe/atlases/raw/master/osten_mouse_10um_v1.1.tar.gz", 3600)
+    ],
+)
+def test_get_download_size(url, real_size):
+    size = utils.get_download_size(url)
+
+    real_size = real_size * 1e6
+
+    assert size == real_size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -82,15 +81,3 @@ def test_get_download_size_HTTPError():
 
         with pytest.raises(HTTPError):
             utils.get_download_size(test_url)
-
-
-def test_retrieve_over_http_get_download_size_exception():
-    with mock.patch("requests.get", autospec=True) as mock_request:
-        mock_response = mock.Mock(spec=requests.Response)
-        mock_response.status_code = 200
-        mock_response.content = b"1234"
-        mock_response.headers = {}
-        mock_request.return_value = mock_response
-
-        with pytest.raises(FileNotFoundError):
-            utils.retrieve_over_http(test_url, Path("/tmp/path"))


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Fix the bug with the progress bar when the content-length header is missing.

**What does this PR do?**
Creates a new function that's called if the content-length header is missing to parse the size from the equivalent 'src' page on GIN.

## References
closes #121 
closes #177

## How has this PR been tested?

The PR was tested locally by downloading several atlases. Existing functionality was checked by running tests. New tests were added to ensure the correct sizes are returned by the new function.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
