### PR TITLE
Prepare for merge and rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# This package has moved!
+
+This package has been renamed to `brainglobe-atlasapi`.
+To continue receiving updates, please switch over to using [the new package](https://github.com/brainglobe/brainglobe-atlasapi).
+
 # BG-atlasAPI
 
 [![Python Version](https://img.shields.io/pypi/pyversions/bg-atlasapi.svg)](https://pypi.org/project/bg-atlasapi)

--- a/bg_atlasapi/__init__.py
+++ b/bg_atlasapi/__init__.py
@@ -1,3 +1,12 @@
+from warnings import warn
+
+warn(
+    "This package has been renamed. "
+    "To continue receiving updates, please use brainglobe-atlasapi instead of this package. "
+    "https://github.com/brainglobe/brainglobe-atlasapi",
+    DeprecationWarning,
+)
+
 from importlib.metadata import PackageNotFoundError, metadata
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ python =
 [testenv]
 extras =
     dev
-commands = pytest -v --color=yes --cov=bg_atlasapi --cov-report=xml
+commands = pytest -v --color=yes --cov=bg_atlasapi --cov-report=xml -W ignore::DeprecationWarning
 """


### PR DESCRIPTION
Prepares the name `bg-atlasapi` for retirement, as part of https://github.com/brainglobe/BrainGlobe/issues/43.

Once this is merged in, we should release a final version, then create a new, locked branch at the state of this final version for archive purposes.

`main` can then be used for hosting the `brainglobe-atlasapi` combined package.